### PR TITLE
Add a test for objects with arrays inside them

### DIFF
--- a/src/tests/deepCopy.test.js
+++ b/src/tests/deepCopy.test.js
@@ -18,4 +18,11 @@ describe("deepCopy", () => {
     expect(newObj.name.first).to.equal("Alpha");
     expect(myObj.name.first).to.equal("Bravo");
   });
+  it("can copy an object that has arrays as values", () => {
+    const myObj = {
+      a: [1],
+      }
+    const newObj = deepCopy(myObj);
+    expect(newObj.a).to.deep.equal(myObj.a);
+  });
 });


### PR DESCRIPTION
test(deepCopy): added a test for copying an object with arrays inside it
Necessary prerequisite to testing and implemented a cyclical graph deep copy