### PR TITLE
Limits of stringify

### DIFF
--- a/src/deepCopy.js
+++ b/src/deepCopy.js
@@ -5,7 +5,7 @@
  * @return {(Object | Array)} - The new, cloned object or array
  */
 const deepCopy = (o) => {
-  return JSON.parse(JSON.stringify(o));
+    return JSON.parse(JSON.stringify(o));
 };
 
 module.exports = deepCopy;

--- a/src/deepCopy.js
+++ b/src/deepCopy.js
@@ -1,3 +1,5 @@
+const v8 = require('v8'); // Node v11 and onwards
+
 /**
  * A function to deeply copy an object
  * (circular references will break it).
@@ -5,7 +7,7 @@
  * @return {(Object | Array)} - The new, cloned object or array
  */
 const deepCopy = (o) => {
-    return JSON.parse(JSON.stringify(o));
+    return v8.deserialize(v8.serialize(o));
 };
 
 module.exports = deepCopy;

--- a/src/tests/deepCopy.test.js
+++ b/src/tests/deepCopy.test.js
@@ -18,4 +18,11 @@ describe("deepCopy", () => {
     expect(newObj.name.first).to.equal("Alpha");
     expect(myObj.name.first).to.equal("Bravo");
   });
+  it("can copy an object that has arrays as values", () => {
+    const myObj = {
+      a: [1],
+      }
+    const newObj = deepCopy(myObj);
+    expect(newObj.a).to.deep.equal(myObj.a);
+  });
 });

--- a/src/tests/deepCopy.test.js
+++ b/src/tests/deepCopy.test.js
@@ -25,20 +25,24 @@ describe("deepCopy", () => {
     const newObj = deepCopy(myObj);
     expect(newObj.a).to.deep.equal(myObj.a);
   });
-  it("can copy an object that has undefined, NaN, Infinity, and functions as values", () => {
+  it("can copy an object that has undefined, NaN, Infinity as values", () => {
     const myObj = {
       a: [1],
-      b: NaN,
-      c: function() {
-        return "Hello!";
-      },
+      b: new Date(),
+      c: undefined,
       d: Infinity,
+      e: NaN,
+      f: false,
       }
     const newObj = deepCopy(myObj);
     expect(newObj.a).to.deep.equal(myObj.a);
-    expect(newObj.b).to.equal(myObj.b); //  AssertionError: expected null to equal NaN
+    expect(newObj.b).to.deep.equal(myObj.b);
     expect(newObj.c).to.equal(myObj.c);
     expect(newObj.d).to.equal(myObj.d);
+    expect(newObj.e).to.not.equal(newObj.e); // test for NaN being copied over
+    // > NaN !== NaN
+    //true
+    expect(newObj.f).to.equal(myObj.f);
   });
 
 });

--- a/src/tests/deepCopy.test.js
+++ b/src/tests/deepCopy.test.js
@@ -25,4 +25,20 @@ describe("deepCopy", () => {
     const newObj = deepCopy(myObj);
     expect(newObj.a).to.deep.equal(myObj.a);
   });
+  it("can copy an object that has undefined, NaN, Infinity, and functions as values", () => {
+    const myObj = {
+      a: [1],
+      b: NaN,
+      c: function() {
+        return "Hello!";
+      },
+      d: Infinity,
+      }
+    const newObj = deepCopy(myObj);
+    expect(newObj.a).to.deep.equal(myObj.a);
+    expect(newObj.b).to.equal(myObj.b); //  AssertionError: expected null to equal NaN
+    expect(newObj.c).to.equal(myObj.c);
+    expect(newObj.d).to.equal(myObj.d);
+  });
+
 });


### PR DESCRIPTION
v8.serialize and deserialize can handle data types like NaN, undefined, new Date() that JSON stringify just can't!